### PR TITLE
refactor: update clock lists state management and employee handling in SiteDetailPage

### DIFF
--- a/components/ClockModal.tsx
+++ b/components/ClockModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useCamera } from "../hooks/useCamera";
 import validateGeolocation from "../utils/validateGeolocation";
-import { ValidationResponse } from "../types";
+import { Employee, ValidationResponse } from "../types";
 
 interface ClockModalProps {
   isOpen: boolean;
@@ -12,8 +12,7 @@ interface ClockModalProps {
     accuracy: number;
     image: string;
   }) => void;
-  onOptimisticUIUpdate: (employeeId: string) => void;
-  selectedEmployee: string | null;
+  selectedEmployee: Employee | null;
   mode: "clockIn" | "clockOut";
   latitude: number;
   longitude: number;
@@ -24,7 +23,6 @@ const ClockModal: React.FC<ClockModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
-  onOptimisticUIUpdate,
   selectedEmployee,
   mode,
   latitude,
@@ -65,15 +63,16 @@ const ClockModal: React.FC<ClockModalProps> = ({
   const handleSubmit = () => {
     if (image && locationValidationResult.isValid && selectedEmployee) {
       try {
-        onOptimisticUIUpdate(selectedEmployee); // Optimistically update UI before submission
-        console.log(`Optimistically updating UI for employee ID: ${selectedEmployee}`);
+        console.log(
+          `Optimistically updating UI for employee: ${selectedEmployee.full_name}`
+        );
         onSubmit({
           latitude,
           longitude,
           accuracy,
           image,
         });
-        console.log('Submitting clock-in/out data');
+        console.log("Submitting clock-in/out data");
         resetImage();
         setSelfieTaken(false); // Resetting selfieTaken state on successful submission
         onClose();
@@ -99,7 +98,7 @@ const ClockModal: React.FC<ClockModalProps> = ({
     <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center">
       <div className="relative p-5 border w-full max-w-sm mx-4 sm:max-w-md lg:max-w-lg bg-white shadow-lg rounded-md">
         <div className="mt-3 text-center">
-          <h3 className="text-lg leading-6 font-medium text-gray-900">{`Please ${mode}`}</h3>
+          <h3 className="text-lg leading-6 font-medium text-gray-900">{`${mode} ${selectedEmployee?.full_name}`}</h3>
           <div className="mt-2">
             <p className="text-sm text-gray-500">
               Capture your selfie and location

--- a/components/EmployeeList.tsx
+++ b/components/EmployeeList.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import Fuse from 'fuse.js';
+import React from "react";
+import Fuse from "fuse.js";
 
 interface Employee {
   employee_id: string;
@@ -7,15 +7,24 @@ interface Employee {
 }
 
 interface EmployeeListProps {
-  employees: Employee[];
+  employees?: Employee[];
   searchTerm: string;
-  onSelectEmployee: (employeeId: string) => void;
+  onSelectEmployee: (employee: Employee) => void;
 }
 
-const EmployeeList: React.FC<EmployeeListProps> = ({ employees, searchTerm, onSelectEmployee }) => {
-  const fuse = new Fuse(employees, { keys: ['full_name'] });
+const EmployeeList: React.FC<EmployeeListProps> = ({
+  employees,
+  searchTerm,
+  onSelectEmployee,
+}) => {
+  if (!employees) {
+    return null;
+  }
+  const fuse = new Fuse(employees, { keys: ["full_name"] });
   const results = fuse.search(searchTerm);
-  const employeeResults = searchTerm ? results.map(result => result.item) : employees;
+  const employeeResults = searchTerm
+    ? results.map((result) => result.item)
+    : employees;
 
   return (
     <ul>
@@ -25,7 +34,7 @@ const EmployeeList: React.FC<EmployeeListProps> = ({ employees, searchTerm, onSe
           className="cursor-pointer hover:bg-gray-100 p-2"
           onClick={() => {
             console.log(`Selecting employee with ID: ${employee.employee_id}`);
-            onSelectEmployee(employee.employee_id);
+            onSelectEmployee(employee);
           }}
         >
           {employee.full_name}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "utils/api.js"
+    "utils/api.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/types.tsx
+++ b/types.tsx
@@ -17,3 +17,19 @@ export interface ModeSwitchProps {
   mode: "clockIn" | "clockOut";
   setMode: (mode: "clockIn" | "clockOut") => void;
 }
+
+export interface ClockEvent {
+  employee_id: string;
+  site_id: string;
+  type: "in" | "out";
+  timestamptz: string;
+  latitude: number;
+  longitude: number;
+  accuracy_meters: number;
+  selfie_data_uri: string;
+}
+
+export interface ClockLists {
+  clockInList: Employee[];
+  clockOutList: Employee[];
+}

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,15 +1,18 @@
 // TODO make this a TS file
 
+import { ClockLists } from "@/types";
+
 import axios from "axios";
 import validateGeolocation from "./validateGeolocation"; // Import the validateCoordinates utility
+import { ClockEvent } from "@/types";
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-export const getSites = async (organisationId) => {
+export const getSites = async (organisationId: string) => {
   try {
     const response = await axios.post(`${apiUrl}/getSites`, { organisationId });
     console.log("Sites fetched successfully.");
     return response.data;
-  } catch (error) {
+  } catch (error: any) {
     console.error(
       "Error fetching sites:",
       error.response ? error.response.data : error
@@ -18,36 +21,24 @@ export const getSites = async (organisationId) => {
   }
 };
 
-export const getClockInList = async (siteId) => {
+export const getClockLists = async (siteId: string) => {
   try {
-    const response = await axios.post(`${apiUrl}/getClockInList`, { siteId });
-    console.log("Clock in list fetched successfully.");
-    return response.data;
-  } catch (error) {
+    const response = await axios.post(`${apiUrl}/get-clock-lists`, { siteId });
+    console.log("Clock lists fetched successfully.");
+    return <ClockLists>response.data;
+  } catch (error: any) {
     console.error(
-      "Error fetching clock in list:",
+      "Error fetching clock lists:",
       error.response ? error.response.data : error
     );
     throw error;
   }
 };
 
-export const getClockOutList = async (siteId) => {
-  try {
-    const response = await axios.post(`${apiUrl}/getClockOutList`, { siteId });
-    console.log("Clock out list fetched successfully.");
-    return response.data;
-  } catch (error) {
-    console.error(
-      "Error fetching clock out list:",
-      error.response ? error.response.data : error
-    );
-    throw error;
-  }
-};
-
-export const clockInEmployee = async (data) => {
-  if (!validateGeolocation(data.latitude, data.longitude, data.accuracy)) {
+export const clockInEmployee = async (data: ClockEvent) => {
+  if (
+    !validateGeolocation(data.latitude, data.longitude, data.accuracy_meters)
+  ) {
     console.error("Invalid location provided, aborting clock in operation.");
     return Promise.reject("Invalid location provided."); // Prevent clocking in with invalid coordinates
   }
@@ -56,7 +47,7 @@ export const clockInEmployee = async (data) => {
     const response = await axios.post(`${apiUrl}/insert-clock-event`, data);
     console.log("Employee clocked in successfully.");
     return response.data;
-  } catch (error) {
+  } catch (error: any) {
     console.error(
       "Error clocking in employee:",
       error.response ? error.response.data : error
@@ -65,8 +56,10 @@ export const clockInEmployee = async (data) => {
   }
 };
 
-export const clockOutEmployee = async (data) => {
-  if (!validateGeolocation(data.latitude, data.longitude, data.accuracy)) {
+export const clockOutEmployee = async (data: ClockEvent) => {
+  if (
+    !validateGeolocation(data.latitude, data.longitude, data.accuracy_meters)
+  ) {
     console.error("Invalid location provided, aborting clock out operation.");
     return Promise.reject("Invalid location provided."); // Prevent clocking out with invalid coordinates
   }
@@ -75,7 +68,7 @@ export const clockOutEmployee = async (data) => {
     const response = await axios.post(`${apiUrl}/insert-clock-event`, data);
     console.log("Employee clocked out successfully.");
     return response.data;
-  } catch (error) {
+  } catch (error: any) {
     console.error(
       "Error clocking out employee:",
       error.response ? error.response.data : error


### PR DESCRIPTION
now using a single backend endpoint to bring back both the clock in & out lists
the employees will move between the lists for a site without having to wait for the backend to bring back fresh data, but it will wait for the clock event to succeed before moving them across